### PR TITLE
Phase 3: Runtime Anchor Injection

### DIFF
--- a/src/components/TeiCustomElement.ts
+++ b/src/components/TeiCustomElement.ts
@@ -1,12 +1,17 @@
 // Extracted Tei custom element logic for testing
 import { customBehaviors } from "../utils";
 import CETEI from "CETEIcean";
+import { injectAnchors, type AnchorIndex } from "../scripts/injectAnchors";
 
 export interface TeiElementConfig {
   rootId?: string;
   useBehaviors: boolean;
   elements: string[];
+  language?: "en" | "gr";
 }
+
+// Store anchor indices globally for access by annotation layer
+export const anchorIndices: Map<string, AnchorIndex> = new Map();
 
 export function applyTeiConfig(element: HTMLElement, config: TeiElementConfig): void {
   if (config.rootId) {
@@ -25,6 +30,30 @@ export function applyTeiConfig(element: HTMLElement, config: TeiElementConfig): 
     ceteicean.els = config.elements;
     ceteicean.utilities.dom = teiDom;
     ceteicean.applyBehaviors();
+
+    // Inject anchors after behaviors are applied (defer until DOM ready)
+    if (config.language) {
+      const lang = config.language;
+      const doInject = () => {
+        const anchorIndex = injectAnchors(element, lang);
+        anchorIndices.set(lang, anchorIndex);
+
+        // Dispatch event for annotation layer
+        element.dispatchEvent(
+          new CustomEvent("tei-anchors-ready", {
+            detail: { language: lang, anchorIndex },
+            bubbles: true,
+          })
+        );
+      };
+
+      // Defer until full document is parsed (comments JSON may come after tei-container)
+      if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", doInject);
+      } else {
+        doInject();
+      }
+    }
   }
 
   element.style.display = "block";
@@ -35,6 +64,7 @@ export function parseDatasetConfig(dataset: DOMStringMap): TeiElementConfig {
     rootId: dataset.rootId,
     useBehaviors: dataset.usebehaviors === "true",
     elements: dataset.elements?.split(",") || [],
+    language: dataset.language as "en" | "gr" | undefined,
   };
 }
 

--- a/src/pages/dialogue/[...dialogueId]/index.astro
+++ b/src/pages/dialogue/[...dialogueId]/index.astro
@@ -75,14 +75,13 @@ const commentsGr = showGreek
       }
     </section>
   </main>
+  {commentsEn && (
+    <script type="application/json" id="comments-en" set:html={JSON.stringify(commentsEn)} />
+  )}
+  {commentsGr && (
+    <script type="application/json" id="comments-gr" set:html={JSON.stringify(commentsGr)} />
+  )}
 </PageLayout>
-
-{commentsEn && (
-  <script type="application/json" id="comments-en" set:html={JSON.stringify(commentsEn)} />
-)}
-{commentsGr && (
-  <script type="application/json" id="comments-gr" set:html={JSON.stringify(commentsGr)} />
-)}
 
 <style>
   .dialogueContainer {

--- a/src/scripts/injectAnchors.ts
+++ b/src/scripts/injectAnchors.ts
@@ -1,0 +1,51 @@
+export type AnchorIndex = Map<string, HTMLElement>;
+
+/**
+ * Parse comments data from JSON script tag
+ */
+function getCommentsData(lang: "en" | "gr"): { anchorPositions: string[] } | null {
+  const script = document.getElementById(`comments-${lang}`);
+  if (!script) return null;
+  try {
+    return JSON.parse(script.textContent || "");
+  } catch {
+    console.warn(`Failed to parse comments-${lang} JSON`);
+    return null;
+  }
+}
+
+/**
+ * Inject anchor spans after tei-lb elements for given positions
+ */
+export function injectAnchors(
+  container: HTMLElement,
+  lang: "en" | "gr"
+): AnchorIndex {
+  const anchorIndex: AnchorIndex = new Map();
+  const data = getCommentsData(lang);
+
+  if (!data || !data.anchorPositions.length) {
+    return anchorIndex;
+  }
+
+  for (const pos of data.anchorPositions) {
+    // Find tei-lb with matching n attribute
+    const lb = container.querySelector(`tei-lb[n="${pos}"]`);
+    if (!lb) {
+      console.warn(`Anchor target not found: tei-lb[n="${pos}"]`);
+      continue;
+    }
+
+    // Create anchor span
+    const anchor = document.createElement("span");
+    anchor.id = `a-${pos}`;
+    anchor.className = "tei-anchor";
+    anchor.dataset.stephanus = pos;
+
+    // Insert after the lb element
+    lb.after(anchor);
+    anchorIndex.set(pos, anchor);
+  }
+
+  return anchorIndex;
+}


### PR DESCRIPTION
## Summary
- Add `injectAnchors.ts` - reads anchor positions from comments JSON, injects `<span>` after `<tei-lb>`
- Hook into `TeiCustomElement.ts` - calls injection after `applyBehaviors()`
- Dispatch `tei-anchors-ready` custom event for annotation layer
- Export `anchorIndices` map for global access

## Files
- `src/scripts/injectAnchors.ts` (new)
- `src/components/TeiCustomElement.ts`

## Test plan
- [x] `npm run build` passes
- [ ] Visit `/dialogue/alcibiades?show=en`, inspect DOM for `<span id="a-103a1" class="tei-anchor">`

Closes #6