### PR TITLE
feat: speaker identity linkage via xml:id / said@who

### DIFF
--- a/src/content/dialogue/alcibiades/en.xml
+++ b/src/content/dialogue/alcibiades/en.xml
@@ -82,10 +82,10 @@
                 <language ident="grc">Greek</language>
             </langUsage>
             <particDesc>
-                <person>
+                <person xml:id="Socrates">
                     <persName>Socrates</persName>
                 </person>
-                <person>
+                <person xml:id="Alcibiades">
                     <persName>Alcibiades</persName>
                 </person>
             </particDesc>

--- a/src/content/dialogue/alcibiades/gr.xml
+++ b/src/content/dialogue/alcibiades/gr.xml
@@ -78,10 +78,10 @@ schematypens="http://relaxng.org/ns/structure/1.0"?>
         <!-- <language ident="eng">English</language> -->
       </langUsage>
       <particDesc>
-        <person>
+        <person xml:id="Σωκράτης">
           <persName>Σωκράτης</persName>
         </person>
-        <person>
+        <person xml:id="Ἀλκιβιάδης">
           <persName>Ἀλκιβιάδης</persName>
         </person>
       </particDesc>

--- a/src/utils/__tests__/behaviors/handle-line-begin.test.ts
+++ b/src/utils/__tests__/behaviors/handle-line-begin.test.ts
@@ -189,6 +189,42 @@ describe('createHandleLineBegin', () => {
     expect(textDiv.classList.contains('stephanus-line')).toBe(true);
   });
 
+  it('sets data-speaker from enclosing tei-said who attribute', () => {
+    document.body.innerHTML = `
+      <tei-said who="#Socrates">
+        <p>
+          <tei-lb n="103a1"></tei-lb>
+          Some text
+          <tei-lb n="103a2"></tei-lb>
+        </p>
+      </tei-said>
+    `;
+    const lb = document.querySelector('tei-lb[n="103a1"]') as HTMLElement;
+    createHandleLineBegin('gr', mockConfig)(lb);
+    expect(lb.dataset.speaker).toBe('Socrates');
+  });
+
+  it('strips leading # from who attribute', () => {
+    document.body.innerHTML = `
+      <tei-said who="#Alcibiades">
+        <p>
+          <tei-lb n="103a1"></tei-lb>
+          Some text
+          <tei-lb n="103a2"></tei-lb>
+        </p>
+      </tei-said>
+    `;
+    const lb = document.querySelector('tei-lb[n="103a1"]') as HTMLElement;
+    createHandleLineBegin('gr', mockConfig)(lb);
+    expect(lb.dataset.speaker).toBe('Alcibiades');
+  });
+
+  it('omits data-speaker when no enclosing tei-said', () => {
+    const lb = document.querySelector('tei-lb[n="103a1"]') as HTMLElement;
+    createHandleLineBegin('gr', mockConfig)(lb);
+    expect(lb.dataset.speaker).toBeUndefined();
+  });
+
   it('finds text node through multiple non-text siblings', () => {
     document.body.innerHTML = `
       <div>

--- a/src/utils/__tests__/behaviors/handle-tei-header.test.ts
+++ b/src/utils/__tests__/behaviors/handle-tei-header.test.ts
@@ -21,10 +21,10 @@ function makeHeader(id = 'test-header') {
         <tei-principal>Gregory Crane</tei-principal>
         <tei-respstmt><resp>Prepared under supervision of</resp></tei-respstmt>
         <tei-funder>Annenberg</tei-funder>
-        <tei-person>
+        <tei-person xml:id="Socrates">
           <tei-persName>SOCRATES</tei-persName>
         </tei-person>
-        <tei-person>
+        <tei-person xml:id="Alcibiades">
           <tei-persName>ALCIBIADES</tei-persName>
         </tei-person>
       </div>
@@ -64,6 +64,29 @@ describe('createHandleTeiHeader("gr")', () => {
     const container = document.querySelector('#dramatis-personae-container-gr');
     expect(container?.textContent).toContain('SOCRATES');
     expect(container?.textContent).toContain('ALCIBIADES');
+  });
+
+  it('sets data-speaker-id on person divs from xml:id', () => {
+    const header = makeHeader();
+    createHandleTeiHeader('gr', mockConfig)(header);
+    const persons = document.querySelectorAll('.person');
+    expect((persons[0] as HTMLElement).dataset.speakerId).toBe('Socrates');
+    expect((persons[1] as HTMLElement).dataset.speakerId).toBe('Alcibiades');
+  });
+
+  it('omits data-speaker-id when person has no xml:id', () => {
+    document.body.innerHTML = `
+      <tei-container>
+        <tei-head></tei-head>
+        <div id="test-header">
+          <tei-person><tei-persName>Anonymous</tei-persName></tei-person>
+        </div>
+      </tei-container>
+    `;
+    const header = document.querySelector('#test-header')!;
+    createHandleTeiHeader('gr', mockConfig)(header);
+    const person = document.querySelector('.person') as HTMLElement;
+    expect(person.dataset.speakerId).toBeUndefined();
   });
 
   it('applies tei-grid class to container', () => {

--- a/src/utils/behaviors/handle-line-begin.ts
+++ b/src/utils/behaviors/handle-line-begin.ts
@@ -43,6 +43,13 @@ export const createHandleLineBegin = (language: Language, config: DialogueConfig
   element.id = `${ref}-${language}`;
   textDiv.id = `${ref}-${language}-text`;
 
+  // Thread speaker identity from enclosing tei-said[@who]
+  const who = element.closest("tei-said")?.getAttribute("who");
+  if (who) {
+    // Strip leading '#' from the IDREF pointer (e.g. "#Socrates" → "Socrates")
+    element.dataset.speaker = who.replace(/^#/, "");
+  }
+
   // Inline marker for narrow viewports — always rendered, CSS controls visibility
   {
     const inlineMarker = doc.createElement("b");

--- a/src/utils/behaviors/handle-tei-header.ts
+++ b/src/utils/behaviors/handle-tei-header.ts
@@ -34,8 +34,10 @@ export const createHandleTeiHeader = (language: Language, config: DialogueConfig
   element.querySelectorAll("tei-person").forEach((personElement) => {
     const person = doc.createElement("div");
     person.setAttribute("class", "person");
+    const speakerId = personElement.getAttribute("xml:id") ?? personElement.getAttribute("id");
     const personName = personElement.querySelector("tei-persName")?.innerHTML;
     person.innerHTML = personName || "";
+    if (speakerId) person.dataset.speakerId = speakerId;
     dramatisPersonae.appendChild(person);
   });
 


### PR DESCRIPTION
## Summary

- Fixes broken IDREF cross-references in `gr.xml` and `en.xml`: adds `xml:id` to all `<person>` elements so `said@who` pointers (`#Σωκράτης`, `#Socrates`, etc.) resolve to real DOM targets
- `handle-tei-header`: carries `xml:id` through as `data-speaker-id` on each dramatis-personae person div — enables future CSS speaker highlighting
- `handle-line-begin`: reads `who` from the nearest `tei-said` ancestor, strips the leading `#`, and emits `data-speaker` on each rendered `tei-lb` line element

No visible UI change — the data attributes are the foundation for Phase 3 speaker styling/highlighting.

## Test plan

- [x] 323 tests passing (`pnpm test`)
- [x] `data-speaker="Σωκράτης"` on first Greek line, `data-speaker="Socrates"` on first English line
- [x] `data-speaker-id="Σωκράτης"` on first dramatis-personae person div