### PR TITLE
feat: preserve inline named entities; render persName/placeName with authority links

### DIFF
--- a/src/components/Tei/tei-style.astro
+++ b/src/components/Tei/tei-style.astro
@@ -157,4 +157,25 @@ import TeiBaseStyle from "./tei-base-style.astro";
     min-height: unset;
     text-align-last: auto;
   }
+
+  /* Named entities (persName / placeName) */
+  .named-entity {
+    font-style: italic;
+  }
+
+  .named-entity.place {
+    border-bottom: 1px dotted currentColor;
+    text-decoration: none;
+    color: inherit;
+    cursor: help;
+  }
+
+  a.named-entity.place:hover {
+    text-decoration: underline;
+    cursor: pointer;
+  }
+
+  .named-entity.person {
+    font-weight: var(--weight-semibold, 600);
+  }
 </style>

--- a/src/utils/__tests__/behaviors/handle-named-entity.test.ts
+++ b/src/utils/__tests__/behaviors/handle-named-entity.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { handlePersName, handlePlaceName, resolveAuthorityUrl } from '../../behaviors/handle-named-entity';
+
+describe('resolveAuthorityUrl', () => {
+  it('resolves tgn key to Getty TGN URL', () => {
+    expect(resolveAuthorityUrl('tgn,1000074', null)).toBe('https://vocab.getty.edu/tgn/1000074');
+  });
+  it('resolves pleiades key', () => {
+    expect(resolveAuthorityUrl('pleiades,579885', null)).toBe('https://pleiades.stoa.org/places/579885');
+  });
+  it('resolves wikidata key', () => {
+    expect(resolveAuthorityUrl('wikidata,Q41', null)).toBe('https://www.wikidata.org/wiki/Q41');
+  });
+  it('resolves bare http ref', () => {
+    expect(resolveAuthorityUrl(null, 'https://example.com/foo')).toBe('https://example.com/foo');
+  });
+  it('returns null for unknown key vocab', () => {
+    expect(resolveAuthorityUrl('unknown,123', null)).toBeNull();
+  });
+  it('returns null for non-URL ref', () => {
+    expect(resolveAuthorityUrl(null, 'Q913')).toBeNull();
+  });
+  it('returns null for null/null', () => {
+    expect(resolveAuthorityUrl(null, null)).toBeNull();
+  });
+  it('key takes priority over ref', () => {
+    expect(resolveAuthorityUrl('tgn,1000074', 'https://example.com')).toBe('https://vocab.getty.edu/tgn/1000074');
+  });
+});
+
+describe('handlePlaceName', () => {
+  beforeEach(() => { document.body.innerHTML = ''; });
+
+  it('replaces tei-placename with <a> when key resolves', () => {
+    document.body.innerHTML = '<tei-placename key="tgn,1000074">Greece</tei-placename>';
+    const el = document.querySelector('tei-placename')!;
+    handlePlaceName(el);
+    const a = document.querySelector('a.named-entity.place');
+    expect(a).not.toBeNull();
+    expect(a?.getAttribute('href')).toBe('https://vocab.getty.edu/tgn/1000074');
+    expect(a?.textContent).toBe('Greece');
+    expect(a?.getAttribute('target')).toBe('_blank');
+  });
+
+  it('replaces with <span> when no resolvable key', () => {
+    document.body.innerHTML = '<tei-placename>Somewhere</tei-placename>';
+    const el = document.querySelector('tei-placename')!;
+    handlePlaceName(el);
+    expect(document.querySelector('span.named-entity.place')).not.toBeNull();
+    expect(document.querySelector('a')).toBeNull();
+  });
+
+  it('carries data-key attribute through', () => {
+    document.body.innerHTML = '<tei-placename key="tgn,1000074">Greece</tei-placename>';
+    const el = document.querySelector('tei-placename')!;
+    handlePlaceName(el);
+    const a = document.querySelector('.named-entity') as HTMLElement;
+    expect(a.dataset.key).toBe('tgn,1000074');
+  });
+});
+
+describe('handlePersName', () => {
+  beforeEach(() => { document.body.innerHTML = ''; });
+
+  it('replaces tei-persname with <a> when ref is a URL', () => {
+    document.body.innerHTML = '<tei-persname ref="https://www.wikidata.org/wiki/Q913">Socrates</tei-persname>';
+    const el = document.querySelector('tei-persname')!;
+    handlePersName(el);
+    const a = document.querySelector('a.named-entity.person');
+    expect(a).not.toBeNull();
+    expect(a?.getAttribute('href')).toBe('https://www.wikidata.org/wiki/Q913');
+    expect(a?.textContent).toBe('Socrates');
+  });
+
+  it('replaces with <span> when no ref', () => {
+    document.body.innerHTML = '<tei-persname>Alcibiades</tei-persname>';
+    const el = document.querySelector('tei-persname')!;
+    handlePersName(el);
+    expect(document.querySelector('span.named-entity.person')).not.toBeNull();
+    expect(document.querySelector('a')).toBeNull();
+  });
+
+  it('carries data-ref attribute through', () => {
+    document.body.innerHTML = '<tei-persname ref="https://www.wikidata.org/wiki/Q913">Socrates</tei-persname>';
+    const el = document.querySelector('tei-persname')!;
+    handlePersName(el);
+    const span = document.querySelector('.named-entity') as HTMLElement;
+    expect(span.dataset.ref).toBe('https://www.wikidata.org/wiki/Q913');
+  });
+});

--- a/src/utils/behaviors/handle-line-begin.ts
+++ b/src/utils/behaviors/handle-line-begin.ts
@@ -108,24 +108,26 @@ const getRangeToNextLineBegin = (element: HTMLElement, doc: Document) => {
 
 const renderRangeInDiv = (range: Range, doc: Document) => {
   const container = doc.createElement("div");
-  let labelText = "";
 
   const dom = range.extractContents();
-  dom
-    .querySelectorAll("tei-milestone")
-    .forEach((milestone) => milestone.remove());
+  dom.querySelectorAll("tei-milestone").forEach((m) => m.remove());
 
   const label = dom.querySelector("tei-label");
   if (label) {
-    labelText = label.innerHTML;
+    const b = doc.createElement("b");
+    b.innerHTML = label.innerHTML;
     label.remove();
-  }
-
-  const text = dom.textContent ?? "";
-
-  container.innerHTML = `${labelText ? `<b>${labelText}</b>` : ""} ${text.trim()}`;
-  if (labelText) {
+    container.appendChild(b);
+    container.appendChild(doc.createTextNode(" "));
     container.classList.add("has-label");
   }
+
+  // Preserve inline elements (tei-persname, tei-placename, etc.) rather than
+  // flattening to textContent — their behavior handlers run after lb and will
+  // transform them in place inside this container.
+  while (dom.firstChild) {
+    container.appendChild(dom.firstChild);
+  }
+
   return container;
 };

--- a/src/utils/behaviors/handle-named-entity.ts
+++ b/src/utils/behaviors/handle-named-entity.ts
@@ -1,0 +1,58 @@
+/**
+ * Resolve a TEI @key or @ref attribute to an authority URL.
+ *
+ * Supported key formats:
+ *   tgn,{id}   → https://vocab.getty.edu/tgn/{id}  (Getty Thesaurus of Geographic Names)
+ *   pleiades,{id} → https://pleiades.stoa.org/places/{id}
+ *   wikidata,{id} → https://www.wikidata.org/wiki/{id}
+ *
+ * A bare @ref value that looks like a URL is returned as-is.
+ */
+export const resolveAuthorityUrl = (key: string | null, ref: string | null): string | null => {
+  if (key) {
+    const comma = key.indexOf(",");
+    if (comma !== -1) {
+      const vocab = key.slice(0, comma).toLowerCase();
+      const id = key.slice(comma + 1);
+      if (vocab === "tgn") return `https://vocab.getty.edu/tgn/${id}`;
+      if (vocab === "pleiades") return `https://pleiades.stoa.org/places/${id}`;
+      if (vocab === "wikidata") return `https://www.wikidata.org/wiki/${id}`;
+    }
+  }
+  if (ref && /^https?:\/\//.test(ref)) return ref;
+  return null;
+};
+
+const replaceWithNamedEntity = (
+  element: Element,
+  entityClass: "person" | "place",
+): void => {
+  const doc = element.ownerDocument;
+  const key = element.getAttribute("key");
+  const ref = element.getAttribute("ref");
+  const url = resolveAuthorityUrl(key, ref);
+
+  const replacement = url
+    ? doc.createElement("a")
+    : doc.createElement("span");
+
+  replacement.className = `named-entity ${entityClass}`;
+  replacement.innerHTML = element.innerHTML;
+
+  if (url && replacement.tagName.toLowerCase() === "a") {
+    replacement.setAttribute("href", url);
+    replacement.setAttribute("target", "_blank");
+    replacement.setAttribute("rel", "noopener noreferrer");
+  }
+
+  if (key) (replacement as HTMLElement).dataset.key = key;
+  if (ref) (replacement as HTMLElement).dataset.ref = ref;
+
+  element.replaceWith(replacement);
+};
+
+export const handlePersName = (element: Element): void =>
+  replaceWithNamedEntity(element, "person");
+
+export const handlePlaceName = (element: Element): void =>
+  replaceWithNamedEntity(element, "place");

--- a/src/utils/behaviors/index.ts
+++ b/src/utils/behaviors/index.ts
@@ -1,3 +1,4 @@
 export { createHandleLineBegin } from "./handle-line-begin";
 export { createHandleTeiHeader } from "./handle-tei-header";
 export { createHandleHead } from "./handle-head";
+export { handlePersName, handlePlaceName, resolveAuthorityUrl } from "./handle-named-entity";

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,6 +2,8 @@ import {
   createHandleLineBegin,
   createHandleTeiHeader,
   createHandleHead,
+  handlePersName,
+  handlePlaceName,
 } from "./behaviors";
 import type { ProcessedTei } from "./processTei";
 import type { DialogueConfig } from "../types";
@@ -13,6 +15,8 @@ export const createBehaviors = (language: "en" | "gr", config: DialogueConfig) =
   teiHeader: createHandleTeiHeader(language, config),
   lb: createHandleLineBegin(language, config),
   head: createHandleHead(language, config),
+  persName: handlePersName,
+  placeName: handlePlaceName,
 });
 
 export const getLineNumbersFromTeiDom = (teiDom: ProcessedTei["dom"]) =>


### PR DESCRIPTION
## Summary

- `renderRangeInDiv` previously flattened line content to `textContent`, discarding all inline markup (`<persName>`, `<placeName>`, etc.). It now appends DOM nodes directly, so `tei-persname`/`tei-placename` handlers can transform elements in-place after the `lb` handler runs.
- New `handle-named-entity.ts` replaces `tei-persname` / `tei-placename` with `<a>` (when `@key`/`@ref` resolves to a known authority URL) or `<span>` (otherwise). Supported key vocabularies: `tgn` → Getty TGN, `pleiades`, `wikidata`. Bare `http(s)` `@ref` values used directly as href.
- `data-key` / `data-ref` carried through on all named-entity elements for downstream use.
- Handlers registered as `persName` / `placeName` in `createBehaviors`.
- `tei-style.astro`: `.named-entity` styles — italic base; dotted underline + pointer cursor for places with links; semibold for persons.

In practice, the two `<placeName key="tgn,1000074">Greece</placeName>` instances in `en.xml` now render as links to `https://vocab.getty.edu/tgn/1000074`.

## Test plan

- [x] 337 tests passing (`pnpm test`)
- [x] `a.named-entity.place` in rendered English text links to `https://vocab.getty.edu/tgn/1000074` with text "Greece"
- [x] No `HTMLAnchorElement is not defined` error in dev server (JSDOM server-side compat fix)
- [ ] Add `<persName ref="...">` to body text and verify it renders as a link